### PR TITLE
Destroy models in reverse-created order.

### DIFF
--- a/src/FactoryGirl.js
+++ b/src/FactoryGirl.js
@@ -155,7 +155,7 @@ export default class FactoryGirl {
   cleanUp() {
     const createdArray = [];
     for (const c of this.created) {
-      createdArray.push(c);
+      createdArray.unshift(c);
     }
     const promise = createdArray.reduce(
       (prev, [adapter, model]) =>


### PR DESCRIPTION
Currently, if you create dependent models on a system with foreign key checks enabled, your tests will error out when running cleanUp because it destroys them in the order they are created.

All that's needed to fix that is to destroy the models in reverse order, so dependant models are destroyed first.