### PR TITLE
Fix 'Cannot read property 'create' of undefined'

### DIFF
--- a/src/adapters/ReduxORMAdapter.js
+++ b/src/adapters/ReduxORMAdapter.js
@@ -7,8 +7,8 @@ export default class ReduxORMAdapter extends DefaultAdapter {
     this.session = session;
   }
 
-  build(modelName, props) {
-    return this.session[modelName].create(props);
+  build(model, props) {
+    return this.session[model.modelName].create(props);
   }
 
   get(model, attr) {


### PR DESCRIPTION
This exception is being thrown when attempting to call the build() function of the adapter because it's taking in the model rather than the modelName attribute.